### PR TITLE
cw -  Add Placeholder for Help Request Index Page

### DIFF
--- a/frontend/src/main/pages/HelpRequests/HelpRequestsCreatePage.js
+++ b/frontend/src/main/pages/HelpRequests/HelpRequestsCreatePage.js
@@ -1,10 +1,10 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 
-export default function TodosCreatePage() {
+export default function HelpRequestsCreatePage() {
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>help req create</h1>
+        <h1>Help Requests</h1>
         <p>
           This is where the create page will go
         </p>

--- a/frontend/src/main/pages/HelpRequests/HelpRequestsEditPage.js
+++ b/frontend/src/main/pages/HelpRequests/HelpRequestsEditPage.js
@@ -1,10 +1,10 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 
-export default function TodosEditPage() {
+export default function HelpRequestsEditPage() {
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>help req edit </h1>
+        <h1>Help Requests</h1>
         <p>
           This is where the edit page will go
         </p>

--- a/frontend/src/main/pages/HelpRequests/HelpRequestsIndexPage.js
+++ b/frontend/src/main/pages/HelpRequests/HelpRequestsIndexPage.js
@@ -1,10 +1,10 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 
-export default function TodosIndexPage() {
+export default function HelpRequestsIndexPage() {
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>help req index</h1>
+        <h1>Help Requests</h1>
         <p>
           This is where the index page will go
         </p>


### PR DESCRIPTION
In this PR, we added placeholder pages for the Help Request index, list, and create pages. Clicking on the links in the navbar should take us to each page, though the pages are currently stubs for when we implement the pages later.