### PR TITLE
bb - Replace ReviewTable placeholder page with one that includes Review Table

### DIFF
--- a/.github/workflows/34-frontend-mutation-testing.yml
+++ b/.github/workflows/34-frontend-mutation-testing.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
 
     strategy:
       matrix:

--- a/frontend/src/fixtures/reviewsFixtures.js
+++ b/frontend/src/fixtures/reviewsFixtures.js
@@ -1,0 +1,39 @@
+const reviewsFixtures = {
+    oneReview: {
+        "id": 1,
+        "itemId": 10,
+        "reviewerEmail": "brockgaucho@ucsb.edu",
+        "stars": 5,
+        "dateReviewed": "2022-03-02T12:00:00",
+        "comments": "Good food today!",
+    },
+    threeReviews: [
+        {
+            "id": 2,
+            "itemId": 314,
+            "reviewerEmail": "chrisgaucho@ucsb.edu",
+            "stars": 4,
+            "dateReviewed": "2022-06-02T12:00:00",
+            "comments": "Decent food today!",
+        },
+        {
+            "id": 3,
+            "itemId": 218,
+            "reviewerEmail": "markgaucho@ucsb.edu",
+            "stars": 2,
+            "dateReviewed": "2022-05-02T12:00:00",
+            "comments": "Bad food today!",
+        },
+        {
+            "id": 4,
+            "itemId": 0,
+            "reviewerEmail": "philgaucho@ucsb.edu",
+            "stars": 1,
+            "dateReviewed": "2022-04-02T12:00:00",
+            "comments": "Worst food today!",
+        }
+    ]
+};
+
+
+export { reviewsFixtures };

--- a/frontend/src/main/components/Reviews/ReviewsTable.js
+++ b/frontend/src/main/components/Reviews/ReviewsTable.js
@@ -1,0 +1,71 @@
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+// import OurTable from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/reviewsUtils"
+//import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
+
+export default function UCSBDatesTable({ reviews, currentUser }) {
+
+    // const navigate = useNavigate();
+
+    // const editCallback = (cell) => {
+    //     navigate(`/menuitemreview/edit/${cell.row.values.id}`)
+    // }
+
+    // Stryker disable all : hard to test for query caching
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/ucsbdates/all"]
+    );
+    // Stryker enable all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+
+    const columns = [
+      {
+          Header: 'id',
+          accessor: 'id', // accessor is the "key" in the data
+      },
+      {
+          Header: 'Item ID',
+          accessor: 'itemId',
+      },
+      {
+          Header: 'Reviewer Email',
+          accessor: 'reviewerEmail',
+      },
+      {
+          Header: 'Stars',
+          accessor: 'stars',
+      },
+      {
+          Header: 'Date Reviewed',
+          accessor: 'dateReviewed',
+      },
+      {
+          Header: 'Comments',
+          accessor: 'comments',
+      }
+  ];
+
+
+    const columnsIfAdmin = [
+        ...columns,
+       // ButtonColumn("Edit", "primary", editCallback, "ReviewsTable"),
+        ButtonColumn("Delete", "danger", deleteCallback, "ReviewsTable")
+    ];
+
+   const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
+
+    
+
+    return <OurTable
+        data={reviews}
+        columns={columnsToDisplay}
+        testid={"ReviewsTable"}
+    />;
+};

--- a/frontend/src/main/pages/Reviews/ReviewsIndexPage.js
+++ b/frontend/src/main/pages/Reviews/ReviewsIndexPage.js
@@ -1,13 +1,29 @@
-import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import React from 'react';
+import { useBackend } from 'main/utils/useBackend'; // use prefix indicates a React Hook
 
-export default function TodosIndexPage() {
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import ReviewsTable from 'main/components/Reviews/ReviewsTable';
+import { useCurrentUser } from 'main/utils/currentUser' // use prefix indicates a React Hook
+
+export default function ReviewsIndexPage() {
+
+  const currentUser = useCurrentUser();
+
+  const { data: reviews, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/menuitemreview/all"],
+            // Stryker disable next-line all
+            { method: "GET", url: "/api/menuitemreview/all" },
+      // Stryker disable next-line all
+      []
+    );
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>review index</h1>
-        <p>
-          This is where the index page will go
-        </p>
+        <h1>Menu Item Reviews</h1>
+        <ReviewsTable reviews={reviews} currentUser={currentUser} />
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/utils/reviewsUtils.js
+++ b/frontend/src/main/utils/reviewsUtils.js
@@ -1,0 +1,17 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+    console.log(message);
+    toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/menuitemreview",
+        method: "DELETE",
+        params: {
+            id: cell.row.values.id
+        }
+    }
+}
+

--- a/frontend/src/tests/components/Reviews/ReviewsTable.test.js
+++ b/frontend/src/tests/components/Reviews/ReviewsTable.test.js
@@ -1,0 +1,126 @@
+import {  render } from "@testing-library/react";
+import { reviewsFixtures } from "fixtures/reviewsFixtures";
+import ReviewsTable from "main/components/Reviews/ReviewsTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("ReviewsTable tests", () => {
+  const queryClient = new QueryClient();
+
+
+  test("renders without crashing for empty table with user not logged in", () => {
+    const currentUser = null;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ReviewsTable reviews={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+  test("renders without crashing for empty table for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ReviewsTable reviews={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("renders without crashing for empty table for admin", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ReviewsTable reviews={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("Has the expected column headers and content for adminUser", () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    const { getByText, getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ReviewsTable reviews={reviewsFixtures.threeReviews} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const testId = "ReviewsTable";
+    const expectedHeaders = ['id',  'Item ID', 'Reviewer Email','Stars','Date Reviewed','Comments'];
+    const expectedFields = ['id', 'itemId','reviewerEmail','stars','dateReviewed','comments'];
+
+    expectedHeaders.forEach((headerText) => {
+      const header = getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(2);
+    expect(getByTestId(`${testId}-cell-row-1-col-stars`)).toHaveTextContent(2);
+    expect(getByTestId(`${testId}-cell-row-0-col-comments`)).toHaveTextContent("Decent food today!");
+    expect(getByTestId(`${testId}-cell-row-1-col-comments`)).toHaveTextContent("Bad food today!");
+
+    // const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    // expect(editButton).toBeInTheDocument();
+    // expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+
+  });
+
+  // test("Edit button navigates to the edit page for admin user", async () => {
+
+  //   const currentUser = currentUserFixtures.adminUser;
+
+  //   const { getByTestId } = render(
+  //     <QueryClientProvider client={queryClient}>
+  //       <MemoryRouter>
+  //         <UCSBDatesTable diningCommons={ucsbDatesFixtures.threeDates} currentUser={currentUser} />
+  //       </MemoryRouter>
+  //     </QueryClientProvider>
+
+  //   );
+
+  //   await waitFor(() => { expect(getByTestId(`UCSBDatesTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+
+  //   const editButton = getByTestId(`UCSBDatesTable-cell-row-0-col-Edit-button`);
+  //   expect(editButton).toBeInTheDocument();
+    
+  //   fireEvent.click(editButton);
+
+  //   await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/ucsbdates/edit/1'));
+
+  // });
+
+
+});
+

--- a/frontend/src/tests/pages/Reviews/ReviewsIndexPage.test.js
+++ b/frontend/src/tests/pages/Reviews/ReviewsIndexPage.test.js
@@ -1,22 +1,59 @@
-import { render } from "@testing-library/react";
-import ReviewsIndexPage from "main/pages/Reviews/ReviewsIndexPage";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import ReviewsIndexPage from "main/pages/Reviews/ReviewsIndexPage";
 
-import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { reviewsFixtures } from "fixtures/reviewsFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import _mockConsole from "jest-mock-console";
 
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
 
 describe("ReviewsIndexPage tests", () => {
 
     const axiosMock =new AxiosMockAdapter(axios);
-    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
 
-    const queryClient = new QueryClient();
-    test("renders without crashing", () => {
+    const testId = "ReviewsTable";
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders without crashing for regular user", () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/menuitemreview/all").reply(200, []);
+
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -24,5 +61,122 @@ describe("ReviewsIndexPage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
+
+
     });
+
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/menuitemreview/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <ReviewsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+    test("renders three reviews without crashing for regular user", async () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/menuitemreview/all").reply(200, reviewsFixtures.threeReviews);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <ReviewsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(  () => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(2); } );
+        expect(getByTestId(`${testId}-cell-row-1-col-itemId`)).toHaveTextContent(218);
+        expect(getByTestId(`${testId}-cell-row-1-col-reviewerEmail`)).toHaveTextContent("markgaucho@ucsb.edu");
+        expect(getByTestId(`${testId}-cell-row-2-col-comments`)).toHaveTextContent("Worst food today!");
+
+    });
+
+    test("renders three reviews without crashing for admin user", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/menuitemreview/all").reply(200, reviewsFixtures.threeReviews);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <ReviewsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(  () => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(2); } );
+        expect(getByTestId(`${testId}-cell-row-1-col-itemId`)).toHaveTextContent(218);
+        expect(getByTestId(`${testId}-cell-row-1-col-reviewerEmail`)).toHaveTextContent("markgaucho@ucsb.edu");
+        expect(getByTestId(`${testId}-cell-row-2-col-comments`)).toHaveTextContent("Worst food today!");
+
+    });
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        setupUserOnly();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/menuitemreview/all").timeout();
+
+        const { queryByTestId, getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <ReviewsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(3); });
+
+        const expectedHeaders = ['id',  'Item ID', 'Reviewer Email','Stars','Date Reviewed','Comments'];
+    
+        expectedHeaders.forEach((headerText) => {
+          const header = getByText(headerText);
+          expect(header).toBeInTheDocument();
+        });
+
+        expect(queryByTestId(`${testId}-cell-row-0-col-code`)).not.toBeInTheDocument();
+    });
+
+    test("test what happens when you click delete, admin", async () => {
+        setupAdminUser();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/menuitemreview/all").reply(200, reviewsFixtures.threeReviews);
+        axiosMock.onDelete("/api/menuitemreview").reply(200, "Review with id 2 was deleted");
+
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <ReviewsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+       expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(2); 
+
+
+        const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+       
+        fireEvent.click(deleteButton);
+
+        await waitFor(() => { expect(mockToast).toBeCalledWith("Review with id 2 was deleted") });
+
+    });
+
 });
+
+

--- a/frontend/src/tests/utils/reviewsUtils.test.js
+++ b/frontend/src/tests/utils/reviewsUtils.test.js
@@ -1,0 +1,58 @@
+import { onDeleteSuccess, cellToAxiosParamsDelete } from "main/utils/reviewsUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("ReviewsUtils", () => {
+
+    describe("onDeleteSuccess", () => {
+
+        test("It puts the message on console.log and in a toast", () => {
+            // arrange
+            const restoreConsole = mockConsole();
+
+            // act
+            onDeleteSuccess("abc");
+
+            // assert
+            expect(mockToast).toHaveBeenCalledWith("abc");
+            expect(console.log).toHaveBeenCalled();
+            const message = console.log.mock.calls[0][0];
+            expect(message).toMatch("abc");
+
+            restoreConsole();
+        });
+
+    });
+    describe("cellToAxiosParamsDelete", () => {
+
+        test("It returns the correct params", () => {
+            // arrange
+            const cell = { row: { values: { id: 17 } } };
+
+            // act
+            const result = cellToAxiosParamsDelete(cell);
+
+            // assert
+            expect(result).toEqual({
+                url: "/api/menuitemreview",
+                method: "DELETE",
+                params: { id: 17 }
+            });
+        });
+
+    });
+});
+
+
+
+
+


### PR DESCRIPTION
In this PR, the Review list page table was integrated for users. To see this run locally and under `Reviews` click list. You should see a table with headers ['id',  'Item ID', 'Reviewer Email','Stars','Date Reviewed','Comments', 'delete'];