### PR TITLE
cw - add HelpRequestTable component to Storybook (along with fixtures)

### DIFF
--- a/frontend/src/fixtures/helpRequestsFixtures.js
+++ b/frontend/src/fixtures/helpRequestsFixtures.js
@@ -1,0 +1,43 @@
+const helpRequestsFixtures = {
+    oneRequest: {
+        "explanation": "Need help with Swagger-ui",
+        "id": 1,
+        "requestTime": "2022-04-20T17:35:00",
+        "requesterEmail": "cgaucho@ucsb.edu",
+        "solved": false,
+        "tableOrBreakoutRoom": "7",
+        "teamId": "s22-5pm-3"
+    },
+    threeRequests: [
+        {
+            "explanation": "Heroku problems",
+            "id": 2,
+            "requestTime": "2022-04-20T18:31:00",
+            "requesterEmail": "ldelplaya@ucsb.edu",
+            "solved": false,
+            "tableOrBreakoutRoom": "11",
+            "teamId": "s22-6pm-3"
+        },
+        {
+            "explanation": "Merge conflict",
+            "id": 3,
+            "requestTime": "2022-04-21T14:15:00",
+            "requesterEmail": "pdg@ucsb.edu",
+            "solved": false,
+            "tableOrBreakoutRoom": "13",
+            "teamId": "s22-6pm-4"
+        },
+        {
+            "explanation": "Mutation Testing",
+            "id": 4,
+            "requestTime": "2022-11-08T15:42:00",
+            "requesterEmail": "cyrilwang@ucsb.edu",
+            "solved": false,
+            "tableOrBreakoutRoom": "10",
+            "teamId": "f22-5pm-4"
+        }
+    ]
+};
+
+
+export { helpRequestsFixtures };

--- a/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
@@ -1,0 +1,74 @@
+// import OurTable, { ButtonColumn } from "main/components/OurTable";
+import OurTable from "main/components/OurTable";
+// import { useBackendMutation } from "main/utils/useBackend";
+// import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBDateUtils"
+// import { useNavigate } from "react-router-dom";
+// import { hasRole } from "main/utils/currentUser";
+
+export default function HelpRequestsTable({ helpRequests, _currentUser }) {
+
+    // const navigate = useNavigate();
+
+    // const editCallback = (cell) => {
+    //     navigate(`/ucsbdates/edit/${cell.row.values.id}`)
+    // }
+
+    // Stryker disable all : hard to test for query caching
+    // const deleteMutation = useBackendMutation(
+    //     cellToAxiosParamsDelete,
+    //     { onSuccess: onDeleteSuccess },
+    //     ["/api/ucsbdates/all"]
+    // );
+    // Stryker enable all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    // const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+
+    const columns = [
+        {
+            Header: 'Explanation',
+            accessor: 'explanation', // accessor is the "key" in the data
+        },
+        {
+            Header: 'Id',
+            accessor: 'id',
+        },
+        {
+            Header: 'Request Time',
+            accessor: 'requestTime',
+        },
+        {
+            Header: 'Requester\'s Email',
+            accessor: 'requesterEmail',
+        },
+        {
+            Header: 'Solved?',
+            id: 'solved',
+            accessor: (row, _rowIndex) => String(row.solved) 
+        },
+        {
+            Header: 'Table or BreakoutRoom Number',
+            accessor: 'tableOrBreakoutRoom',
+        },
+        {
+            Header: 'Team Id',
+            accessor: 'teamId',
+        }
+    ];
+
+    // const columnsIfAdmin = [
+    //     ...columns,
+    //     ButtonColumn("Edit", "primary", editCallback, "UCSBDatesTable"),
+    //     ButtonColumn("Delete", "danger", deleteCallback, "UCSBDatesTable")
+    // ];
+
+    // const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
+
+    const columnsToDisplay = columns;
+
+    return <OurTable
+        data={helpRequests}
+        columns={columnsToDisplay}
+        testid={"HelpRequestsTable"}
+    />;
+};

--- a/frontend/src/stories/components/HelpRequests/HelpRequestTable.stories.js
+++ b/frontend/src/stories/components/HelpRequests/HelpRequestTable.stories.js
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import HelpRequestsTable from "main/components/HelpRequests/HelpRequestsTable";
+import { helpRequestsFixtures } from 'fixtures/helpRequestsFixtures';
+// import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+
+export default {
+    title: 'components/HelpRequests/HelpRequestsTable',
+    component: HelpRequestsTable
+};
+
+const Template = (args) => {
+    return (
+        <HelpRequestsTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    helpRequests: []
+};
+
+export const ThreeRequests = Template.bind({});
+
+ThreeRequests.args = {
+    helpRequests: helpRequestsFixtures.threeRequests
+};
+
+// export const ThreeRequestsAsAdmin = Template.bind({});
+
+// ThreeRequestsAsAdmin.args = {
+//     helpRequests: helpRequestsFixtures.threeRequests,
+//     currentUser: currentUserFixtures.adminUser
+// };
+


### PR DESCRIPTION
In this PR, we implemented the `HelpRequestTable` by creating each of its columns / headers with its respective variable from the API. I chose not to implement the edit and delete functions in this PR, and will hold that off for a later PR. I also added the file `HelpRequestsTable.stories.js` so that the table can be run on Storybook, and tested it using the `helpRequestsFixtures.js` file, where the values stored in that file should show up in our test table on Storybook.