### PR TITLE
cw - Add HelpRequestTable component to Storybook (along with fixtures)

### DIFF
--- a/frontend/src/fixtures/helpRequestsFixtures.js
+++ b/frontend/src/fixtures/helpRequestsFixtures.js
@@ -1,0 +1,43 @@
+const helpRequestsFixtures = {
+    oneRequest: {
+        "explanation": "Need help with Swagger-ui",
+        "id": 1,
+        "requestTime": "2022-04-20T17:35:00",
+        "requesterEmail": "cgaucho@ucsb.edu",
+        "solved": false,
+        "tableOrBreakoutRoom": "7",
+        "teamId": "s22-5pm-3"
+    },
+    threeRequests: [
+        {
+            "explanation": "Heroku problems",
+            "id": 2,
+            "requestTime": "2022-04-20T18:31:00",
+            "requesterEmail": "ldelplaya@ucsb.edu",
+            "solved": false,
+            "tableOrBreakoutRoom": "11",
+            "teamId": "s22-6pm-3"
+        },
+        {
+            "explanation": "Merge conflict",
+            "id": 3,
+            "requestTime": "2022-04-21T14:15:00",
+            "requesterEmail": "pdg@ucsb.edu",
+            "solved": false,
+            "tableOrBreakoutRoom": "13",
+            "teamId": "s22-6pm-4"
+        },
+        {
+            "explanation": "Mutation Testing",
+            "id": 4,
+            "requestTime": "2022-11-08T15:42:00",
+            "requesterEmail": "cyrilwang@ucsb.edu",
+            "solved": false,
+            "tableOrBreakoutRoom": "10",
+            "teamId": "f22-5pm-4"
+        }
+    ]
+};
+
+
+export { helpRequestsFixtures };

--- a/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
@@ -1,0 +1,74 @@
+// import OurTable, { ButtonColumn } from "main/components/OurTable";
+import OurTable from "main/components/OurTable";
+// import { useBackendMutation } from "main/utils/useBackend";
+// import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBDateUtils"
+// import { useNavigate } from "react-router-dom";
+// import { hasRole } from "main/utils/currentUser";
+
+export default function HelpRequestsTable({ helpRequests, _currentUser }) {
+
+    // const navigate = useNavigate();
+
+    // const editCallback = (cell) => {
+    //     navigate(`/ucsbdates/edit/${cell.row.values.id}`)
+    // }
+
+    // Stryker disable all : hard to test for query caching
+    // const deleteMutation = useBackendMutation(
+    //     cellToAxiosParamsDelete,
+    //     { onSuccess: onDeleteSuccess },
+    //     ["/api/ucsbdates/all"]
+    // );
+    // Stryker enable all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    // const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+
+    const columns = [
+        {
+            Header: 'Explanation',
+            accessor: 'explanation', // accessor is the "key" in the data
+        },
+        {
+            Header: 'Id',
+            accessor: 'id',
+        },
+        {
+            Header: 'Request Time',
+            accessor: 'requestTime',
+        },
+        {
+            Header: 'Requester\'s Email',
+            accessor: 'requesterEmail',
+        },
+        {
+            Header: 'Solved?',
+            id: 'solved',
+            accessor: (row, _rowIndex) => String(row.solved) 
+        },
+        {
+            Header: 'Table or BreakoutRoom Number',
+            accessor: 'tableOrBreakoutRoom',
+        },
+        {
+            Header: 'Team Id',
+            accessor: 'teamId',
+        }
+    ];
+
+    // const columnsIfAdmin = [
+    //     ...columns,
+    //     ButtonColumn("Edit", "primary", editCallback, "UCSBDatesTable"),
+    //     ButtonColumn("Delete", "danger", deleteCallback, "UCSBDatesTable")
+    // ];
+
+    // const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
+
+    const columnsToDisplay = columns;
+
+    return <OurTable
+        data={helpRequests}
+        columns={columnsToDisplay}
+        testid={"HelpRequestsTable"}
+    />;
+};

--- a/frontend/src/stories/components/HelpRequests/HelpRequestTable.stories.js
+++ b/frontend/src/stories/components/HelpRequests/HelpRequestTable.stories.js
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import HelpRequestsTable from "main/components/HelpRequests/HelpRequestsTable";
+import { helpRequestsFixtures } from 'fixtures/helpRequestsFixtures';
+// import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+
+export default {
+    title: 'components/HelpRequests/HelpRequestsTable',
+    component: HelpRequestsTable
+};
+
+const Template = (args) => {
+    return (
+        <HelpRequestsTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    helpRequests: []
+};
+
+export const ThreeRequests = Template.bind({});
+
+ThreeRequests.args = {
+    helpRequests: helpRequestsFixtures.threeRequests
+};
+
+// export const ThreeRequestsAsAdmin = Template.bind({});
+
+// ThreeRequestsAsAdmin.args = {
+//     helpRequests: helpRequestsFixtures.threeRequests,
+//     currentUser: currentUserFixtures.adminUser
+// };
+

--- a/frontend/src/tests/components/HelpRequests/HelpRequestsTable.test.js
+++ b/frontend/src/tests/components/HelpRequests/HelpRequestsTable.test.js
@@ -1,0 +1,126 @@
+import {  render } from "@testing-library/react";
+import { helpRequestsFixtures } from "fixtures/helpRequestsFixtures";
+import HelpRequestsTable from "main/components/HelpRequests/HelpRequestsTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("HelpRequestsTable tests", () => {
+  const queryClient = new QueryClient();
+
+
+  test("renders without crashing for empty table with user not logged in", () => {
+    const currentUser = null;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestsTable helpRequests={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+  test("renders without crashing for empty table for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestsTable helpRequests={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("renders without crashing for empty table for admin", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestsTable helpRequests={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("Has the expected column headers and content for adminUser", () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    const { getByText, getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestsTable helpRequests={helpRequestsFixtures.threeRequests} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedHeaders = ['Explanation',  'Id', 'Request Time','Requester\'s Email','Solved?','Table or BreakoutRoom Number','Team Id'];
+    const expectedFields = ['explanation', 'id','requestTime', 'requesterEmail','solved','tableOrBreakoutRoom','teamId'];
+    const testId = "HelpRequestsTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(getByTestId(`${testId}-cell-row-0-col-explanation`)).toHaveTextContent("Heroku problems");
+    expect(getByTestId(`${testId}-cell-row-1-col-explanation`)).toHaveTextContent("Merge conflict");
+    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(2);
+    expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(3);
+
+    // const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    // expect(editButton).toBeInTheDocument();
+    // expect(editButton).toHaveClass("btn-primary");
+
+    // const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    // expect(deleteButton).toBeInTheDocument();
+    // expect(deleteButton).toHaveClass("btn-danger");
+
+  });
+
+  // test("Edit button navigates to the edit page for admin user", async () => {
+
+  //   const currentUser = currentUserFixtures.adminUser;
+
+  //   const { getByTestId } = render(
+  //     <QueryClientProvider client={queryClient}>
+  //       <MemoryRouter>
+  //         <UCSBDatesTable diningCommons={ucsbDatesFixtures.threeDates} currentUser={currentUser} />
+  //       </MemoryRouter>
+  //     </QueryClientProvider>
+
+  //   );
+
+  //   await waitFor(() => { expect(getByTestId(`UCSBDatesTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+
+  //   const editButton = getByTestId(`UCSBDatesTable-cell-row-0-col-Edit-button`);
+  //   expect(editButton).toBeInTheDocument();
+    
+  //   fireEvent.click(editButton);
+
+  //   await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/ucsbdates/edit/1'));
+
+  // });
+
+
+});
+


### PR DESCRIPTION
In this PR, I created the HelpRequestTable and added it to Storybook, and created the tests for the HelpRequestTable as well. I chose not to implement the `edit` or `delete` columns to our table just yet, and will include that in a future PR. To test this PR, checkout this branch `CyrilHelpRequest` and run `npm run storybook` to check if the table shows up in the Storybook, if it contains the correct headers, and if the values show up in the table. 