### PR TITLE
cw - Replace HelpRequestTable placeholder page with one that includes HelpRequest table

### DIFF
--- a/.github/workflows/34-frontend-mutation-testing.yml
+++ b/.github/workflows/34-frontend-mutation-testing.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
 
     strategy:
       matrix:

--- a/frontend/src/main/pages/HelpRequests/HelpRequestsIndexPage.js
+++ b/frontend/src/main/pages/HelpRequests/HelpRequestsIndexPage.js
@@ -15,6 +15,7 @@ export default function HelpRequestsIndexPage() {
       ["/api/HelpRequest/all"],
             // Stryker disable next-line StringLiteral,ObjectLiteral : since "GET" is default, "" is an equivalent mutation
             { method: "GET", url: "/api/HelpRequest/all" },
+      // Stryker disable next-line all
       []
     );
 

--- a/frontend/src/main/pages/HelpRequests/HelpRequestsIndexPage.js
+++ b/frontend/src/main/pages/HelpRequests/HelpRequestsIndexPage.js
@@ -1,13 +1,28 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend'; // use prefix indicates a React Hook
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import HelpRequestsTable from 'main/components/HelpRequests/HelpRequestsTable';
+import { useCurrentUser } from 'main/utils/currentUser' // use prefix indicates a React Hook
 
 export default function HelpRequestsIndexPage() {
+
+  const currentUser = useCurrentUser();
+
+  const { data: helpRequests, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/HelpRequest/all"],
+            // Stryker disable next-line StringLiteral,ObjectLiteral : since "GET" is default, "" is an equivalent mutation
+            { method: "GET", url: "/api/HelpRequest/all" },
+      []
+    );
+
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>Help Requests</h1>
-        <p>
-          This is where the index page will go
-        </p>
+        <HelpRequestsTable helpRequests={helpRequests} currentUser={currentUser} />
       </div>
     </BasicLayout>
   )

--- a/frontend/src/tests/pages/HelpRequests/HelpRequestsIndexPage.test.js
+++ b/frontend/src/tests/pages/HelpRequests/HelpRequestsIndexPage.test.js
@@ -1,22 +1,59 @@
-import { render } from "@testing-library/react";
-import HelpRequestsIndexPage from "main/pages/HelpRequests/HelpRequestsIndexPage";
+import { _fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import HelpRequestsIndexPage from "main/pages/HelpRequests/HelpRequestsIndexPage";
 
-import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { helpRequestsFixtures } from "fixtures/helpRequestsFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import _mockConsole from "jest-mock-console";
 
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
 
 describe("HelpRequestsIndexPage tests", () => {
 
     const axiosMock =new AxiosMockAdapter(axios);
-    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
 
-    const queryClient = new QueryClient();
-    test("renders without crashing", () => {
+    const testId = "HelpRequestsTable";
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders without crashing for regular user", () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/HelpRequest/all").reply(200, []);
+
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -24,7 +61,144 @@ describe("HelpRequestsIndexPage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
+
+
     });
 
-});
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/HelpRequest/all").reply(200, []);
 
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HelpRequestsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+    test("renders three helpRequests without crashing for regular user", async () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/HelpRequest/all").reply(200, helpRequestsFixtures.threeRequests);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HelpRequestsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(  () => { expect(getByTestId(`${testId}-cell-row-0-col-teamId`)).toHaveTextContent("s22-6pm-3"); } );
+        expect(getByTestId(`${testId}-cell-row-1-col-teamId`)).toHaveTextContent("s22-6pm-4");
+        expect(getByTestId(`${testId}-cell-row-2-col-teamId`)).toHaveTextContent("f22-5pm-4");
+
+    });
+
+    test("renders three helpRequests without crashing for admin user", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/HelpRequest/all").reply(200, helpRequestsFixtures.threeRequests);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HelpRequestsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-teamId`)).toHaveTextContent("s22-6pm-3"); });
+        expect(getByTestId(`${testId}-cell-row-1-col-teamId`)).toHaveTextContent("s22-6pm-4");
+        expect(getByTestId(`${testId}-cell-row-2-col-teamId`)).toHaveTextContent("f22-5pm-4");
+
+    });
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        setupUserOnly();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/HelpRequest/all").timeout();
+
+        const { queryByTestId, getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HelpRequestsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(3); });
+
+        const expectedHeaders = ['Explanation',  'Id', 'Request Time','Requester\'s Email','Solved?','Table or BreakoutRoom Number','Team Id'];
+    
+        expectedHeaders.forEach((headerText) => {
+          const header = getByText(headerText);
+          expect(header).toBeInTheDocument();
+        });
+
+        expect(queryByTestId(`${testId}-cell-row-0-col-teamId`)).not.toBeInTheDocument();
+    });
+
+    // test("test what happens when you click delete, admin", async () => {
+    //     setupAdminUser();
+
+    //     const queryClient = new QueryClient();
+    //     axiosMock.onGet("/api/HelpRequest/all").reply(200, helpRequestsFixtures.threeRequests);
+    //     axiosMock.onDelete("/api/HelpRequest", {params: {code: "1"}}).reply(200, "HelpRequest with id 1 was deleted");
+
+
+    //     const { getByTestId } = render(
+    //         <QueryClientProvider client={queryClient}>
+    //             <MemoryRouter>
+    //                 <HelpRequestsIndexPage />
+    //             </MemoryRouter>
+    //         </QueryClientProvider>
+    //     );
+
+    //     await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+    //    expect(getByTestId(`${testId}-cell-row-0-col-teamId`)).toHaveTextContent("s22-5pm-3"); 
+
+
+    //     const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    //     expect(deleteButton).toBeInTheDocument();
+       
+    //     fireEvent.click(deleteButton);
+
+    //     await waitFor(() => { expect(mockToast).toBeCalledWith("Help Request with id 1 was deleted") });
+
+    // });
+
+    // test("test what happens when you click edit as an admin", async () => {
+    //     setupAdminUser();
+
+    //     const queryClient = new QueryClient();
+    //     axiosMock.onGet("/api/HelpRequest/all").reply(200, diningCommonsFixtures.threeCommons);
+
+    //     const { getByTestId } = render(
+    //         <QueryClientProvider client={queryClient}>
+    //             <MemoryRouter>
+    //                 <DiningCommonsIndexPage />
+    //             </MemoryRouter>
+    //         </QueryClientProvider>
+    //     );
+
+    //     await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-code`)).toBeInTheDocument(); });
+
+    //     expect(getByTestId(`${testId}-cell-row-0-col-code`)).toHaveTextContent("de-la-guerra"); 
+
+
+    //     const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    //     expect(editButton).toBeInTheDocument();
+       
+    //     fireEvent.click(editButton);
+
+    //     await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/diningCommons/edit/de-la-guerra'));
+
+});


### PR DESCRIPTION
In this PR, we updated `HelpRequestIndexPage.js` such that we no longer see the placeholder page, and instead see our actual `HelpRequest` table when clicking on `List` from the HelpRequest dropdown. To test, run team03 locally using mvn spring-boot:run and npm start, and check if the HelpRequest table can be seen.