### PR TITLE
cw - added Delete Column to HelpRequest Table 

### DIFF
--- a/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
@@ -1,28 +1,38 @@
-// import OurTable, { ButtonColumn } from "main/components/OurTable";
-import OurTable from "main/components/OurTable";
-// import { useBackendMutation } from "main/utils/useBackend";
-// import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBDateUtils"
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { useBackendMutation } from "main/utils/useBackend";
+import { onDeleteSuccess } from "main/utils/UCSBDateUtils"
 // import { useNavigate } from "react-router-dom";
-// import { hasRole } from "main/utils/currentUser";
+import { hasRole } from "main/utils/currentUser";
 
-export default function HelpRequestsTable({ helpRequests, _currentUser }) {
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/HelpRequest",
+        method: "DELETE",
+        params: {
+            id: cell.row.values.id
+        }
+    }
+}
+
+
+export default function HelpRequestsTable({ helpRequests, currentUser }) {
 
     // const navigate = useNavigate();
 
     // const editCallback = (cell) => {
-    //     navigate(`/ucsbdates/edit/${cell.row.values.id}`)
+    //     navigate(`/HelpRequests/edit/${cell.row.values.id}`)
     // }
 
     // Stryker disable all : hard to test for query caching
-    // const deleteMutation = useBackendMutation(
-    //     cellToAxiosParamsDelete,
-    //     { onSuccess: onDeleteSuccess },
-    //     ["/api/ucsbdates/all"]
-    // );
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/HelpRequest/all"]
+    );
     // Stryker enable all 
 
     // Stryker disable next-line all : TODO try to make a good test for this
-    // const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
 
     const columns = [
         {
@@ -56,19 +66,19 @@ export default function HelpRequestsTable({ helpRequests, _currentUser }) {
         }
     ];
 
-    // const columnsIfAdmin = [
-    //     ...columns,
-    //     ButtonColumn("Edit", "primary", editCallback, "UCSBDatesTable"),
-    //     ButtonColumn("Delete", "danger", deleteCallback, "UCSBDatesTable")
-    // ];
+    const testid = "HelpRequestsTable"
 
-    // const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
+    const columnsIfAdmin = [
+        ...columns,
+        // ButtonColumn("Edit", "primary", editCallback, "UCSBDatesTable"),
+        ButtonColumn("Delete", "danger", deleteCallback, testid)
+    ];
 
-    const columnsToDisplay = columns;
+    const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
 
     return <OurTable
         data={helpRequests}
         columns={columnsToDisplay}
-        testid={"HelpRequestsTable"}
+        testid={testid}
     />;
 };

--- a/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestsTable.js
@@ -1,18 +1,9 @@
 import OurTable, { ButtonColumn } from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
-import { onDeleteSuccess } from "main/utils/UCSBDateUtils"
+import { onDeleteSuccess, cellToAxiosParamsDelete } from "main/utils/HelpRequestsUtils"
 // import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 
-export function cellToAxiosParamsDelete(cell) {
-    return {
-        url: "/api/HelpRequest",
-        method: "DELETE",
-        params: {
-            id: cell.row.values.id
-        }
-    }
-}
 
 
 export default function HelpRequestsTable({ helpRequests, currentUser }) {

--- a/frontend/src/main/utils/HelpRequestsUtils.js
+++ b/frontend/src/main/utils/HelpRequestsUtils.js
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+    console.log(message);
+    toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/HelpRequest",
+        method: "DELETE",
+        params: {
+            id: cell.row.values.id
+        }
+    }
+}

--- a/frontend/src/stories/components/HelpRequests/HelpRequestTable.stories.js
+++ b/frontend/src/stories/components/HelpRequests/HelpRequestTable.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import HelpRequestsTable from "main/components/HelpRequests/HelpRequestsTable";
 import { helpRequestsFixtures } from 'fixtures/helpRequestsFixtures';
-// import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
 
 export default {
     title: 'components/HelpRequests/HelpRequestsTable',
@@ -27,10 +27,10 @@ ThreeRequests.args = {
     helpRequests: helpRequestsFixtures.threeRequests
 };
 
-// export const ThreeRequestsAsAdmin = Template.bind({});
+export const ThreeRequestsAsAdmin = Template.bind({});
 
-// ThreeRequestsAsAdmin.args = {
-//     helpRequests: helpRequestsFixtures.threeRequests,
-//     currentUser: currentUserFixtures.adminUser
-// };
+ThreeRequestsAsAdmin.args = {
+    helpRequests: helpRequestsFixtures.threeRequests,
+    currentUser: currentUserFixtures.adminUser
+};
 

--- a/frontend/src/tests/components/HelpRequests/HelpRequestsTable.test.js
+++ b/frontend/src/tests/components/HelpRequests/HelpRequestsTable.test.js
@@ -5,7 +5,6 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
 
-
 const mockedNavigate = jest.fn();
 
 jest.mock('react-router-dom', () => ({
@@ -96,6 +95,8 @@ describe("HelpRequestsTable tests", () => {
     expect(deleteButton).toHaveClass("btn-danger");
 
   });
+
+
 
   // test("Edit button navigates to the edit page for admin user", async () => {
 

--- a/frontend/src/tests/components/HelpRequests/HelpRequestsTable.test.js
+++ b/frontend/src/tests/components/HelpRequests/HelpRequestsTable.test.js
@@ -91,9 +91,9 @@ describe("HelpRequestsTable tests", () => {
     // expect(editButton).toBeInTheDocument();
     // expect(editButton).toHaveClass("btn-primary");
 
-    // const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
-    // expect(deleteButton).toBeInTheDocument();
-    // expect(deleteButton).toHaveClass("btn-danger");
+    const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
 
   });
 

--- a/frontend/src/tests/pages/HelpRequests/HelpRequestsIndexPage.test.js
+++ b/frontend/src/tests/pages/HelpRequests/HelpRequestsIndexPage.test.js
@@ -1,4 +1,4 @@
-import { _fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import HelpRequestsIndexPage from "main/pages/HelpRequests/HelpRequestsIndexPage";
@@ -9,7 +9,7 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { helpRequestsFixtures } from "fixtures/helpRequestsFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import _mockConsole from "jest-mock-console";
+// import mockConsole from "jest-mock-console";
 
 
 const mockToast = jest.fn();
@@ -145,35 +145,35 @@ describe("HelpRequestsIndexPage tests", () => {
         expect(queryByTestId(`${testId}-cell-row-0-col-teamId`)).not.toBeInTheDocument();
     });
 
-    // test("test what happens when you click delete, admin", async () => {
-    //     setupAdminUser();
+    test("test what happens when you click delete, admin", async () => {
+        setupAdminUser();
 
-    //     const queryClient = new QueryClient();
-    //     axiosMock.onGet("/api/HelpRequest/all").reply(200, helpRequestsFixtures.threeRequests);
-    //     axiosMock.onDelete("/api/HelpRequest", {params: {code: "1"}}).reply(200, "HelpRequest with id 1 was deleted");
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/HelpRequest/all").reply(200, helpRequestsFixtures.threeRequests);
+        // axiosMock.onDelete("/api/HelpRequest", {params: {id: 2}}).reply(200, "HelpRequest with id 2 was deleted");
+        axiosMock.onDelete("/api/HelpRequest").reply(200, "HelpRequest with id 2 was deleted");
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HelpRequestsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+        expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(2); 
 
 
-    //     const { getByTestId } = render(
-    //         <QueryClientProvider client={queryClient}>
-    //             <MemoryRouter>
-    //                 <HelpRequestsIndexPage />
-    //             </MemoryRouter>
-    //         </QueryClientProvider>
-    //     );
-
-    //     await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
-
-    //    expect(getByTestId(`${testId}-cell-row-0-col-teamId`)).toHaveTextContent("s22-5pm-3"); 
-
-
-    //     const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
-    //     expect(deleteButton).toBeInTheDocument();
+        const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
        
-    //     fireEvent.click(deleteButton);
+        fireEvent.click(deleteButton);
 
-    //     await waitFor(() => { expect(mockToast).toBeCalledWith("Help Request with id 1 was deleted") });
+        await waitFor(() => { expect(mockToast).toBeCalledWith("HelpRequest with id 2 was deleted") });
 
-    // });
+    });
 
     // test("test what happens when you click edit as an admin", async () => {
     //     setupAdminUser();

--- a/frontend/src/tests/utils/HelpRequestsUtils.test.js
+++ b/frontend/src/tests/utils/HelpRequestsUtils.test.js
@@ -1,0 +1,53 @@
+import { onDeleteSuccess, cellToAxiosParamsDelete } from "main/utils/HelpRequestsUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("UCSBDateUtils", () => {
+
+    describe("onDeleteSuccess", () => {
+
+        test("It puts the message on console.log and in a toast", () => {
+            // arrange
+            const restoreConsole = mockConsole();
+
+            // act
+            onDeleteSuccess("abc");
+
+            // assert
+            expect(mockToast).toHaveBeenCalledWith("abc");
+            expect(console.log).toHaveBeenCalled();
+            const message = console.log.mock.calls[0][0];
+            expect(message).toMatch("abc");
+
+            restoreConsole();
+        });
+
+    });
+    describe("cellToAxiosParamsDelete", () => {
+
+        test("It returns the correct params", () => {
+            // arrange
+            const cell = { row: { values: { id: 17 } } };
+
+            // act
+            const result = cellToAxiosParamsDelete(cell);
+
+            // assert
+            expect(result).toEqual({
+                url: "/api/HelpRequest",
+                method: "DELETE",
+                params: { id: 17 }
+            });
+        });
+
+    });
+});

--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -22,10 +22,10 @@ public class HelpRequest {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;
  
-  String requesterEmail;
-  String teamId;
-  String tableOrBreakoutRoom;
-  LocalDateTime requestTime;
-  String explanation;
-  boolean solved;
+  private String requesterEmail;
+  private String teamId;
+  private String tableOrBreakoutRoom;
+  private LocalDateTime requestTime;
+  private String explanation;
+  private boolean solved;
 }


### PR DESCRIPTION
In this PR, we added the Delete Column to our HelpRequestTable and its respectivef tests, which allows us to delete help requests from our table. To test this, run it on localhost, add a new table row through swagger-ui, and test the delete button, which should delete the row. 